### PR TITLE
update documentation hop translator

### DIFF
--- a/content/community/contribution-guides/translation-contribution-guide.adoc
+++ b/content/community/contribution-guides/translation-contribution-guide.adoc
@@ -20,7 +20,7 @@ mvn clean install
 After a successful build:
 [source,bash]
 cd assemblies/client/target
-unzip hop-assemblies-client-0.1.0-SNAPSHOT.zip
+unzip hop-client-2.1.0-SNAPSHOT.zip
 cd hop
 
 From your new Hop build:


### PR DESCRIPTION
the name of zip now is this partner hop-client-X.X.0-SNAPSHOT.zip, not more hop-assemblies-client-X.X.0-SNAPSHOT.zip