### PR TITLE
Update _index.adoc href

### DIFF
--- a/content/_index.adoc
+++ b/content/_index.adoc
@@ -118,7 +118,7 @@ Hop is an [Apache Software Foundation](https://www.apache.org) project, availabl
 
 [Sources](./community/sources/), [mailing lists](./community/mailing-list/), [issue tracker](./community/support/): it's fully open, you can access directly.
 
-We also love contributions: don't hesitate to [contribute](./community/contributing/). You can contribute by <a href="https://github.com/apache/hop-website/edit/master/content/_index.md">editing this page</a>!
+We also love contributions: don't hesitate to [contribute](./community/contributing/). You can contribute by <a href="https://github.com/apache/hop-website/edit/main/content/_index.adoc">editing this page</a>!
 
 [Be Involved In The Community](./community/contributing/)
 


### PR DESCRIPTION
The href pointed to an old branch and file, updated to point to current _index.adoc file