### PR TITLE
Issue #8188 : drop the technical documentation component

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,3 +5,16 @@ RewriteBase "/"
 # Redirect /manual/2.19.0 to latest
 
 RewriteRule "^manual/2.19.0(/.*)$" "/manual/latest$1" [R=permanent,L]
+
+# The technical documentation was folded into the user and developer manuals.
+# Redirect its pages, in any published version, to their new homes.
+
+RewriteRule "^tech-manual/[^/]+/hop-vs-kettle/hop-import\.html$" "/manual/latest/hop-tools/hop-import.html" [R=permanent,L]
+RewriteRule "^tech-manual/[^/]+/hop-vs-kettle/(.*)$" "/manual/latest/hop-vs-kettle/$1" [R=permanent,L]
+RewriteRule "^tech-manual/[^/]+/docker-container\.html$" "/manual/latest/docker-container.html" [R=permanent,L]
+RewriteRule "^tech-manual/[^/]+/hop-web-docker\.html$" "/manual/latest/hop-web-docker.html" [R=permanent,L]
+RewriteRule "^tech-manual/[^/]+/disable-ui-elements\.html$" "/manual/latest/hop-gui/disable-ui-elements.html" [R=permanent,L]
+RewriteRule "^tech-manual/[^/]+/logging/.*$" "/dev-manual/latest/architecture/logging-and-debugging.html" [R=permanent,L]
+RewriteRule "^tech-manual/[^/]+/hop-logo-and-icons\.html$" "/community/branding/" [R=permanent,L]
+RewriteRule "^tech-manual/[^/]+/_attachments/BrandGuideline_Hop\.pdf$" "/graphical_resources/brand_guideline_hop.pdf" [R=permanent,L]
+RewriteRule "^tech-manual/(.*)$" "/manual/latest/" [R=permanent,L]

--- a/config.toml
+++ b/config.toml
@@ -51,30 +51,23 @@ unsafe= true
     url = "/manual/latest/"
 
 [[menu.main]]
-    name = "Technical Documentation"
-    parent = "docs"
-    weight = 3
-    identifier = "docs-tech-manual"
-    url = "/tech-manual/latest/"
-
-[[menu.main]]
     name = "Developer Documentation"
     parent = "docs"
-    weight = 4
+    weight = 3
     identifier = "docs-dev-manual"
     url = "/dev-manual/latest/"
 
 [[menu.main]]
     name = "Architecture"
     parent = "docs"
-    weight = 5
+    weight = 4
     identifier = "docs-architecture"
     url = "/docs/architecture/"
 
 [[menu.main]]
     name = "Roadmap"
     parent = "docs"
-    weight = 6
+    weight = 5
     identifier = "docs-roadmap"
     url = "/docs/roadmap/"
 
@@ -131,6 +124,13 @@ unsafe= true
     weight = 7
     identifier = "community-ethos"
     url = "/community/ethos/"
+
+[[menu.main]]
+    name = "Logo and Icons"
+    parent = "community"
+    weight = 8
+    identifier = "community-branding"
+    url = "/community/branding/"
 
 [[menu.main]]
     name = "Download"

--- a/content/community/branding.adoc
+++ b/content/community/branding.adoc
@@ -1,0 +1,71 @@
+---
+title: "Logo and Icons"
+---
+
+The Apache Hop logo should be used as the main reference to the Apache Hop project.
+
+The Apache Hop icon should be used in graphical user interfaces like Apache Hop's Hop Gui. The icon should not be used as a replacement for the Apache Hop logo.
+
+Vector sources are available as link:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/cmyk_print/hop_logo_cmyk.pdf[CMYK PDF] and link:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/rgb_web/hop_logo_rgb.pdf[RGB PDF].
+
+== Style guide
+
+link:/graphical_resources/brand_guideline_hop.pdf[BrandGuideline_Hop.pdf]
+
+== CMYK for printing
+
+=== Logo
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/cmyk_print/jpg/hop_logo_cmyk-4.jpg[Hop logo CMYK, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/cmyk_print/jpg/hop_logo_cmyk-2.jpg[Hop logo CMYK, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/cmyk_print/jpg/hop_logo_cmyk-1.jpg[Hop logo CMYK, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/cmyk_print/jpg/hop_logo_cmyk-3.jpg[Hop logo CMYK, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/cmyk_print/jpg/hop_logo_cmyk-5.jpg[Hop logo CMYK, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/cmyk_print/jpg/hop_logo_cmyk-6.jpg[Hop logo CMYK, width="50%"]
+
+=== Icon
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/cmyk_print/jpg/hop_logo_cmyk-10.jpg[Hop icon CMYK, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/cmyk_print/jpg/hop_logo_cmyk-7.jpg[Hop icon CMYK, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/cmyk_print/jpg/hop_logo_cmyk-8.jpg[Hop icon CMYK, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/cmyk_print/jpg/hop_logo_cmyk-9.jpg[Hop icon CMYK, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/cmyk_print/jpg/hop_logo_cmyk-12.jpg[Hop icon CMYK, width="50%"]
+
+== RGB for web usage
+
+=== Logo
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/rgb_web/jpg/hop_logo_rgb-4.jpg[Hop logo RGB, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/rgb_web/jpg/hop_logo_rgb-1.jpg[Hop logo RGB, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/rgb_web/jpg/hop_logo_rgb-2.jpg[Hop logo RGB, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/rgb_web/jpg/hop_logo_rgb-3.jpg[Hop logo RGB, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/rgb_web/jpg/hop_logo_rgb-5.jpg[Hop logo RGB, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/rgb_web/jpg/hop_logo_rgb-6.jpg[Hop logo RGB, width="50%"]
+
+=== Icon
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/rgb_web/jpg/hop_logo_rgb-10.jpg[Hop icon RGB, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/rgb_web/jpg/hop_logo_rgb-7.jpg[Hop icon RGB, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/rgb_web/jpg/hop_logo_rgb-8.jpg[Hop icon RGB, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/rgb_web/jpg/hop_logo_rgb-9.jpg[Hop icon RGB, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/rgb_web/jpg/hop_logo_rgb-11.jpg[Hop icon RGB, width="50%"]
+
+image:/graphical_resources/hop_logo_and_icon/hop_logo_and_icon/rgb_web/jpg/hop_logo_rgb-12.jpg[Hop icon RGB, width="50%"]

--- a/content/community/contribution-guides/documentation-contribution-guide.adoc
+++ b/content/community/contribution-guides/documentation-contribution-guide.adoc
@@ -74,7 +74,7 @@ TIP: The pull request review and merge is a manual process. Even though it usual
 
 All Apache Hop documentation is maintained in the same git repository as the code base.
 
-=== User manual and Technical documentation
+=== User manual
 
 The easiest way to contribute documentation is to fork https://github.com/apache/hop[Hop’s repository] on GitHub into your own GitHub account by clicking on the fork button at the top right. If you have no GitHub account, you can create one for free.
 
@@ -84,7 +84,6 @@ Next, clone your fork to your local machine.
 git clone https://github.com/<your-user-name>/hop.git
 
 The user manual documentation is located in the docs/hop-user-manual/ subdirectory.
-The technical documentation is located in the docs/hop-tech-manual/ subdirectory.
 
 
 === API documentation

--- a/site-local.yml
+++ b/site-local.yml
@@ -21,9 +21,6 @@ content:
     start_path: /docs/hop-user-manual/
   - url: ../hop/
     branches: HEAD
-    start_path: /docs/hop-tech-manual/
-  - url: ../hop/
-    branches: HEAD
     start_path: /docs/hop-dev-manual/
     
 ui:

--- a/site.yml
+++ b/site.yml
@@ -43,21 +43,6 @@ content:
       - release/2.18.0
       - release/2.18.1
       - release/2.19.0
-    start_path: /docs/hop-tech-manual/
-  - url: git@github.com:apache/hop.git
-    branches: 
-      - main
-      - release/2.10.0
-      - release/2.11.0
-      - release/2.12.0
-      - release/2.13.0
-      - release/2.14.0
-      - release/2.15.0
-      - release/2.16.0
-      - release/2.17.0
-      - release/2.18.0
-      - release/2.18.1
-      - release/2.19.0
     start_path: /docs/hop-dev-manual/
     
 ui:


### PR DESCRIPTION
Companion to apache/hop#8189, which folds the technical documentation pages into the user and developer manuals. Both should merge together.

Changes:

* remove the `tech-manual` source from `site.yml` and `site-local.yml`
* drop the "Technical Documentation" entry from the Documentation menu and close the weight gap
* add **Community > Logo and Icons** (`content/community/branding.adoc`), pointing at the brand assets this site already hosts under `/graphical_resources/` — the manual carried a duplicate copy of the same 30 files
* drop the tech manual from the documentation contribution guide
* redirect every `/tech-manual/<version>/*` URL to its new home

The redirects matter: removing the source from `site.yml` also removes the component for the 2.10–2.19 versions it was built for, so the old URLs would 404 at the next site build. The rules match any version segment, so `/tech-manual/2.16.0/docker-container.html` and `/tech-manual/latest/docker-container.html` both land on the user manual page, with a catch-all for anything not named explicitly. The 2020 roundup blog post that links into the tech manual keeps working through those rules.

`.htaccess` is copied into the `asf-site` branch by the Jenkinsfile, so the rules go live with the site build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)